### PR TITLE
Add support for 2-byte raw wave unsigned

### DIFF
--- a/src/GUI/SettingsWidget/DeviceConfiguration.cpp
+++ b/src/GUI/SettingsWidget/DeviceConfiguration.cpp
@@ -19,11 +19,12 @@ DeviceConfiguration::DeviceConfiguration(QWidget *parent) :
     connect(ui->devices_cb, SIGNAL(currentIndexChanged(int)),
             this, SLOT(chooseDevice(int)));
     connect(ui->baudrates_cb, SIGNAL(currentIndexChanged(int)),
-            this, SLOT(chooseBaudrate(int)));
+            this, SLOT(chooseBaudRate(int)));
+    connect(ui->types_cb, SIGNAL(currentIndexChanged(int)),
+            this, SLOT(chooseType(int)));
     connect(tg, SIGNAL(statusChanged(ThinkGearStatus)),
             this, SLOT(onThinkGearStatusChanged(ThinkGearStatus)));
-
-    initBaudRates();
+    setupDeviceTypes();
     refresh();
 
 }
@@ -33,9 +34,11 @@ DeviceConfiguration::~DeviceConfiguration()
     delete ui;
 }
 
-void DeviceConfiguration::initBaudRates()
+void DeviceConfiguration::setupBaudRates()
 {
-    for (auto bRate : ThinkgearBaudrates) {
+    int idx = ui->types_cb->currentIndex();
+    ui->baudrates_cb->clear();
+    for (auto bRate : TGTypes[idx].baudrates) {
         ui->baudrates_cb->addItem(QString::number(bRate), bRate);
     }
 }
@@ -46,7 +49,7 @@ void DeviceConfiguration::chooseDevice(int id)
     tg->setPortName(portName);
 }
 
-void DeviceConfiguration::chooseBaudrate(int id)
+void DeviceConfiguration::chooseBaudRate(int id)
 {
     int bRate = ui->baudrates_cb->currentData().toInt();
     tg->setBaudRate(bRate);
@@ -64,5 +67,19 @@ void DeviceConfiguration::refresh()
     }
 }
 
+void DeviceConfiguration::setupDeviceTypes()
+{
+    for (auto dev : TGTypes) {
+        auto devName = QString(dev.name.c_str());
+        ui->types_cb->addItem(devName, devName);
+    }
+}
+
 void DeviceConfiguration::onThinkGearStatusChanged(ThinkGearStatus status)
 {}
+
+void DeviceConfiguration::chooseType(int id)
+{
+    tg->setupDeviceType(id);
+    setupBaudRates();
+}

--- a/src/GUI/SettingsWidget/DeviceConfiguration.h
+++ b/src/GUI/SettingsWidget/DeviceConfiguration.h
@@ -19,15 +19,17 @@ public:
     ~DeviceConfiguration();
 public slots:
     void chooseDevice(int id);
-    void chooseBaudrate(int id);
+    void chooseBaudRate(int id);
+    void chooseType(int id);
     void connectDevice() { tg->open(); }
     void disconnectDevice() { tg->close(); }
+    void setupDeviceTypes();
     void refresh();
 public slots:
     void onThinkGearStatusChanged(ThinkGearStatus status);
 private:
     Ui::DeviceConfiguration *ui;
-    void initBaudRates();
+    void setupBaudRates();
 protected:
     Status status;
     QThinkGear *tg;

--- a/src/GUI/SettingsWidget/DeviceConfiguration.ui
+++ b/src/GUI/SettingsWidget/DeviceConfiguration.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>291</width>
-    <height>82</height>
+    <height>131</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,7 +20,7 @@
    <property name="geometry">
     <rect>
      <x>0</x>
-     <y>20</y>
+     <y>70</y>
      <width>201</width>
      <height>27</height>
     </rect>
@@ -30,7 +30,7 @@
    <property name="geometry">
     <rect>
      <x>210</x>
-     <y>20</y>
+     <y>70</y>
      <width>81</width>
      <height>27</height>
     </rect>
@@ -40,7 +40,7 @@
    <property name="geometry">
     <rect>
      <x>0</x>
-     <y>0</y>
+     <y>50</y>
      <width>76</width>
      <height>19</height>
     </rect>
@@ -53,7 +53,7 @@
    <property name="geometry">
     <rect>
      <x>220</x>
-     <y>0</y>
+     <y>50</y>
      <width>76</width>
      <height>19</height>
     </rect>
@@ -66,7 +66,7 @@
    <property name="geometry">
     <rect>
      <x>210</x>
-     <y>50</y>
+     <y>100</y>
      <width>81</width>
      <height>27</height>
     </rect>
@@ -79,7 +79,7 @@
    <property name="geometry">
     <rect>
      <x>0</x>
-     <y>50</y>
+     <y>100</y>
      <width>101</width>
      <height>27</height>
     </rect>
@@ -92,13 +92,36 @@
    <property name="geometry">
     <rect>
      <x>100</x>
-     <y>50</y>
+     <y>100</y>
      <width>101</width>
      <height>27</height>
     </rect>
    </property>
    <property name="text">
     <string>Disconnect</string>
+   </property>
+  </widget>
+  <widget class="QComboBox" name="types_cb">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>20</y>
+     <width>281</width>
+     <height>27</height>
+    </rect>
+   </property>
+  </widget>
+  <widget class="QLabel" name="type_label">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>141</width>
+     <height>19</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Device Type</string>
    </property>
   </widget>
  </widget>

--- a/src/GUI/SettingsWidget/SettingsWidget.ui
+++ b/src/GUI/SettingsWidget/SettingsWidget.ui
@@ -32,9 +32,9 @@
     <property name="geometry">
      <rect>
       <x>20</x>
-      <y>40</y>
+      <y>30</y>
       <width>301</width>
-      <height>121</height>
+      <height>131</height>
      </rect>
     </property>
    </widget>

--- a/src/QThinkGear/QThinkGear.cpp
+++ b/src/QThinkGear/QThinkGear.cpp
@@ -9,7 +9,6 @@ QThinkGear::QThinkGear(QObject *parent) :
     connect(&_device, SIGNAL(readyRead()), this, SLOT(onReadyRead()));
     _device.setReadBufferSize(BUFFER_SIZE);
     QThinkGear::currentInstance = this;
-    THINKGEAR_initParser(&_parser, PARSER_TYPE_PACKETS, QThinkGearDataHandle, &_handler);
     _status = ThinkGearStatus::NoConnected;
     _opened = false;
 }
@@ -74,4 +73,11 @@ void QThinkGear::changeStatus(ThinkGearStatus status)
 {
     _status = status;
     emit statusChanged(status);
+}
+
+
+void QThinkGear::setupDeviceType(int id)
+{
+    auto type = TGTypes[id];
+    THINKGEAR_initParser(&_parser, type.parsertype, type.dataHandle, &_handler);
 }

--- a/src/QThinkGear/QThinkGear.h
+++ b/src/QThinkGear/QThinkGear.h
@@ -9,9 +9,22 @@
 
 #define BUFFER_SIZE 2048
 
-const int ThinkgearBaudrates[] {
-    57600, 9600
+typedef struct _ThinkgearDeviceType {
+    std::string name;
+    std::vector<int> baudrates;
+    unsigned char parsertype;
+    void (*dataHandle)(unsigned char extendedCodeLevel,
+                       unsigned char code,
+                       unsigned char numBytes,
+                       const unsigned char *value,
+                       void *customData );
+} ThinkgearDeviceType;
+
+const ThinkgearDeviceType TGTypes[] {
+    {"Neurosky ThinkGear", {57600, 9600}, PARSER_TYPE_PACKETS, QThinkGearDataHandle},
+    {"2-byte raw wave (unsigned)", {38400, 9600}, PARSER_TYPE_2BYTERAW, QTwoByteRawDataHandle }
 };
+
 typedef enum {
     Idle,
     Reading,
@@ -23,6 +36,7 @@ class QThinkGear : public QObject
 public:
     QThinkGear(QObject *parent = nullptr);
     ~QThinkGear();
+    void setupDeviceType(int id);
     static QThinkGear* qThinkGear() { return currentInstance; }
     void addListener(QObject* listener) {
         _handler.addListener(listener); 

--- a/src/QThinkGear/QThinkGearDataHandler.cpp
+++ b/src/QThinkGear/QThinkGearDataHandler.cpp
@@ -10,7 +10,21 @@ void QThinkGearDataHandle( unsigned char extendedCodeLevel,
 {
     auto handler = reinterpret_cast<QThinkGearDataHandler*>(customData);
     handler->pushData(TGData(code, numBytes, value));
-}                    
+}
+
+void QTwoByteRawDataHandle( unsigned char extendedCodeLevel,
+                            unsigned char code,
+                            unsigned char numBytes,
+                            const unsigned char *value,
+                            void *customData )
+{
+    auto handler = reinterpret_cast<QThinkGearDataHandler*>(customData);
+    short val = 0;
+    val |= (value[0]&0x3F)<<6;
+    val |= value[1]&0x3F;
+    val -= 2048;
+    emit handler->onRaw(val);
+}
 
 QThinkGearDataHandler::QThinkGearDataHandler(QObject *parent)
 : QObject(parent)

--- a/src/QThinkGear/QThinkGearDataHandler.h
+++ b/src/QThinkGear/QThinkGearDataHandler.h
@@ -40,6 +40,12 @@ void QThinkGearDataHandle( unsigned char extendedCodeLevel,
                             unsigned char numBytes,
                             const unsigned char *value,
                             void *customData );
+
+void QTwoByteRawDataHandle( unsigned char extendedCodeLevel,
+                            unsigned char code,
+                            unsigned char numBytes,
+                            const unsigned char *value,
+                            void *customData );
 class QThinkGearListener;                            
 class QThinkGearDataHandler : public QObject
 {


### PR DESCRIPTION
Added basic support for 2-byte unsigned big-endian raw wave.
Supported values are 12-bit, where
First byte (MSB): 10HH HHHH
Second byte (LSB): 01LL LLLL.
For now supported baudrates are: 9600 and 38400.